### PR TITLE
Add GetAll() to completion interface

### DIFF
--- a/completer.go
+++ b/completer.go
@@ -15,4 +15,5 @@ type Completion struct {
 type Completer interface {
 	// Returns all completions for the given prompt, up to the given limit (or all if limit < 0).
 	GetCompletions(prompt string, limit int) []Completion
+	GetAll() []Completion
 }

--- a/completion_source_test.go
+++ b/completion_source_test.go
@@ -96,3 +96,7 @@ func (c *MockCompleter) GetCompletions(prompt string, limit int) []Completion {
 
 	return results[:limit]
 }
+
+func (c *MockCompleter) GetAll() []Completion {
+	return c.Results
+}

--- a/sources/nasdaq/completer.go
+++ b/sources/nasdaq/completer.go
@@ -53,6 +53,10 @@ func NewCompleter() (*NasdaqCompleter, error) {
 	return completer, nil
 }
 
+func (c *NasdaqCompleter) GetAll() []tac.Completion {
+	return c.completions
+}
+
 // GetCompletions returns completions for the given prompt.
 func (c *NasdaqCompleter) GetCompletions(prompt string, limit int) []tac.Completion {
 	var results []tac.Completion


### PR DESCRIPTION
This change adds a way to get all completions at once. This should be useful when the consumer wants to provide their own lookup mechanism.